### PR TITLE
Fix KernelSU bootloop

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 if [ "$1" = "clean" ];then
     cd adbd_helper && ndk-build clean
@@ -11,4 +11,4 @@ cp README.md magisk_module/
 cp adbd_helper/libs/arm64-v8a/adbd magisk_module/system/apex/com.android.adbd/bin/adbd
 cp adbd_helper/libs/arm64-v8a/libadb_root_helper.so magisk_module/system/lib64/
 
-(cd magisk_module && zip -r ../adb_root.zip * -x "*.DS_Store")
+(cd magisk_module && zip -r ../adb_root.zip -x "*.DS_Store" -- *)

--- a/magisk_module/customize.sh
+++ b/magisk_module/customize.sh
@@ -1,4 +1,4 @@
-#! /system/bin/sh
+#!/system/bin/sh
 
 ADBD_APEX="/apex/com.android.adbd/"
 
@@ -12,15 +12,15 @@ install() {
 
     if [ -e $SYSTEM_ADBD_PATH_REAL ];then
         ui_print "backup $SYSTEM_ADBD_PATH_REAL.."
-        cp -f $SYSTEM_ADBD_PATH_REAL $MOD_ADBD_PATH_REAL
+        cp -f $SYSTEM_ADBD_PATH_REAL "$MOD_ADBD_PATH_REAL"
     else
         ui_print "backup $SYSTEM_ADBD_PATH.."
-        cp -f $SYSTEM_ADBD_PATH $MOD_ADBD_PATH_REAL
+        cp -f $SYSTEM_ADBD_PATH "$MOD_ADBD_PATH_REAL"
     fi
 
     ui_print "set permissions.."
-    chmod +x $MOD_ADBD_PATH
-    chcon --reference=$SYSTEM_ADBD_PATH $MOD_ADBD_PATH $MOD_ADBD_PATH_REAL
+    chmod +x "$MOD_ADBD_PATH"
+    chcon --reference=$SYSTEM_ADBD_PATH "$MOD_ADBD_PATH" "$MOD_ADBD_PATH_REAL"
 }
 
 if [ -d "$ADBD_APEX" ]; then
@@ -28,7 +28,7 @@ if [ -d "$ADBD_APEX" ]; then
 
     install
 else
-    echo "ro.debuggable=1" >> $MODPATH/system.prop
+    echo "ro.debuggable=1" >> "$MODPATH"/system.prop
 fi
-    
+
 ui_print "adb_root installed"

--- a/magisk_module/post-fs-data.sh
+++ b/magisk_module/post-fs-data.sh
@@ -3,4 +3,4 @@
 MODDIR=${0%/*}
 
 # todo: overlayfs?
-mount --bind $MODDIR/system/apex/com.android.adbd/bin /apex/com.android.adbd/bin
+mount --bind "$MODDIR"/system/apex/com.android.adbd/bin /apex/com.android.adbd/bin

--- a/magisk_module/service.sh
+++ b/magisk_module/service.sh
@@ -4,10 +4,10 @@ MODDIR=${0%/*}
 max_wait=180
 interval=1
 BOOT_COMPLETED=false
-while [[ "$max_wait" -gt 0 ]]; do
+while [ $max_wait -gt 0 ]; do
   pidof adbd
   ret=$0
-  if [ $ret -eq 0 ];then
+  if [ "$ret" -eq 0 ];then
     BOOT_COMPLETED=true
     break
   fi
@@ -16,5 +16,5 @@ while [[ "$max_wait" -gt 0 ]]; do
 done
 
 if [ "$BOOT_COMPLETED" = "false" ];then
-    touch $MODDIR/disable
+    touch "$MODDIR"/disable
 fi


### PR DESCRIPTION
The service.sh script was using non-compliant syntax and operators.

```
sh: /data/adb/modules/adb_root/service.sh: bad number
```
