### PR TITLE
Fix module disable after boot

### DIFF
--- a/magisk_module/service.sh
+++ b/magisk_module/service.sh
@@ -6,7 +6,7 @@ interval=1
 BOOT_COMPLETED=false
 while [ $max_wait -gt 0 ]; do
   pidof adbd
-  ret=$0
+  ret=$?
   if [ "$ret" -eq 0 ];then
     BOOT_COMPLETED=true
     break


### PR DESCRIPTION
$0 is the name of script, not the return code. So it will always disable itself because `ret` will never eq 0.