### PR TITLE
Fix undefined behavior and crash in execve wrapper

### DIFF
--- a/adbd_helper/jni/main.cpp
+++ b/adbd_helper/jni/main.cpp
@@ -1,17 +1,18 @@
 #include <unistd.h>
 
+#include <stdlib.h>
+
 int main(int argc, char** argv) {
     const char* real_adbd = "/apex/com.android.adbd/bin/adbd.real";
 
-    char* const envp[] = {
-        const_cast<char*>("LD_PRELOAD=/system/lib64/libadb_root_helper.so"),
-    };
+    setenv("LD_PRELOAD", "/system/lib64/libadb_root_helper.so", 1);
 
     // u:r:adbd:s0 is restricted
     char* const new_argv[] = { 
         argv[0],
-        const_cast<char*>("--root_seclabel=u:r:magisk:s0")
+        const_cast<char*>("--root_seclabel=u:r:magisk:s0"),
+        nullptr
     };
 
-    return execve(real_adbd, new_argv, envp);
+    return execv(real_adbd, new_argv);
 }


### PR DESCRIPTION
On certain Apple Silicon chips and Android versions, the lack of NULL-termination in the new_argv array passed to execve() causes random memory garbage to be read, leading to adbd instantly crashing or failing to start. This PR fixes the issue by utilizing setenv() to preserve the environment and execv() with a properly terminated array.