### PR TITLE
Fix LD_PRELOAD leaking to child processes

### DIFF
--- a/adbd_helper/jni/lib.cpp
+++ b/adbd_helper/jni/lib.cpp
@@ -1,7 +1,12 @@
 #include <string>
+#include <cstdlib>
 #include <dlfcn.h>
 
 __BEGIN_DECLS
+__attribute__((constructor)) void stop_preload_leak() {
+    unsetenv("LD_PRELOAD");
+}
+
 int __android_log_is_debuggable() { return 1; }
 
 int property_get(const char* key, char* value, const char* default_value) {

--- a/adbd_helper/jni/lib.cpp
+++ b/adbd_helper/jni/lib.cpp
@@ -3,8 +3,8 @@
 #include <dlfcn.h>
 
 __BEGIN_DECLS
-__attribute__((constructor)) void stop_preload_leak() {
-    unsetenv("LD_PRELOAD");
+__attribute__((constructor)) static void stop_preload_leak() {
+    (void)unsetenv("LD_PRELOAD");
 }
 
 int __android_log_is_debuggable() { return 1; }


### PR DESCRIPTION
The LD_PRELOAD is leaking to child processes ran within adb, which is undesirable. This keeps it confined to adbd